### PR TITLE
Feature/use installed cfd build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@
 *.exe
 *.out
 *.app
+
+# build cache
+build/
+external/cfd-core
+external/cfd
+external/googletest
+external/libwally-core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ####################
 # options
 ####################
+option(ENABLE_SHARED "enable shared library (ON or OFF. default:ON)" ON)
 option(ENABLE_TESTS "enable code tests (ON or OFF. default:ON)" ON)
 if(NOT WIN32)
 #option(TARGET_RPATH "target rpath list (separator is ';') (default:)" "")

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # cfd-dlc
 Library for creating and managing Discrete Logarithm Contracts (DLC)
+
+## build
+
+### full build
+```
+./scripts/build.sh
+```
+
+### quick build (use installed cfd)
+
+use pkg-config.
+
+- macos: `brew install pkg-config`
+
+1. install cfd. (on initial or update only.)
+```
+git clone git@github.com:cryptogarageinc/cfd.git v0.0.10
+cmake -S . -B build
+cmake -DENABLE_SHARED=on -DENABLE_JS_WRAPPER=off -DENABLE_TESTS=off -DTARGET_RPATH=/usr/local/lib -DCMAKE_BUILD_TYPE=Release --build build
+cmake --build build --parallel 4 --config Release
+cd build && sudo make install -j 4
+(or cmake --install build)
+
+attention: support is shared library only.
+```
+
+update installed library, need cleanup installed file. script:
+  `https://github.com/cryptogarageinc/cfd/blob/master/tools/cleanup_install_files.sh`
+
+2. build cfd-dlc (on clean state)
+```
+./scripts/build.sh
+```

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,5 +1,22 @@
 project(external_download NONE)
 
+####################
+# find pkgconfig
+####################
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND AND (NOT WIN32))
+pkg_check_modules(CFD cfd)
+if(NOT CFD_FOUND)
+set(CFD_INSTALLED   FALSE)
+else()  # PkgConfig
+set(CFD_INSTALLED   ${CFD_FOUND})
+endif()
+else()  # PkgConfig
+set(CFD_INSTALLED   FALSE)
+endif()  # PkgConfig
+
+if(NOT ${CFD_INSTALLED})
+
 # load file
 set(EXTERNAL_DEBUG_FILENAME  external_project_debug.config)
 set(DEBUG_VERSION_FILE  ${CMAKE_SOURCE_DIR}/${EXTERNAL_DEBUG_FILENAME})
@@ -52,3 +69,50 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/external/${TEMPLATE_PROJECT_NAME}
                  ${DIR_PATH}/build)
 set_property(GLOBAL PROPERTY ${TEMPLATE_PROJECT_NAME} 1)
 endif()
+
+endif(NOT ${CFD_INSTALLED})
+
+
+# googletest
+if(ENABLE_TESTS)
+if(GTEST_TARGET_VERSION)
+set(GTEST_TARGET_TAG  ${GTEST_TARGET_VERSION})
+message(STATUS "[external project local] google-test target=${GTEST_TARGET_VERSION}")
+else()
+set(GTEST_TARGET_TAG  release-1.8.1)
+endif()
+
+set(TEMPLATE_PROJECT_NAME           googletest)
+set(TEMPLATE_PROJECT_GIT_REPOSITORY  git@github.com:google/googletest.git)
+set(TEMPLATE_PROJECT_GIT_TAG        ${GTEST_TARGET_TAG})
+set(PROJECT_EXTERNAL  "${CMAKE_SOURCE_DIR}/external/${TEMPLATE_PROJECT_NAME}/external")
+set(DL_PATH "${CFD_DLC_ROOT_BINARY_DIR}/external/${TEMPLATE_PROJECT_NAME}/download")
+
+get_property(PROP_VALUE  GLOBAL  PROPERTY ${TEMPLATE_PROJECT_NAME})
+if(PROP_VALUE)
+  message(STATUS "[exist directory] ${TEMPLATE_PROJECT_NAME} exist")
+else()
+configure_file(template_CMakeLists.txt.in ${DL_PATH}/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -S . -B ${DL_PATH}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${DL_PATH} )
+if(result)
+  message(FATAL_ERROR "CMake step for ${TEMPLATE_PROJECT_NAME} failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build ${DL_PATH}
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${DL_PATH} )
+if(result)
+  message(FATAL_ERROR "Build step for ${TEMPLATE_PROJECT_NAME} failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/external/${TEMPLATE_PROJECT_NAME}
+                 ${CFD_DLC_ROOT_BINARY_DIR}/${TEMPLATE_PROJECT_NAME}/build)
+set_property(GLOBAL PROPERTY ${TEMPLATE_PROJECT_NAME} 1)
+endif()
+endif() # ENABLE_TESTS

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cmake -S . -B build
 pushd build
-make
+make -j 4
 popd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,9 +93,6 @@ set(USE_SCALAR_4X64 true)
 project(cfddlc CXX)
 # set(LIBRARY_PREFIX $<IF:$<PLATFORM_ID:Windows>,,lib>)
 # set(LIBRARY_SUFFIX $<IF:$<PLATFORM_ID:Windows>,dll,$<IF:$<PLATFORM_ID:Darwin>,dylib,so>>)
-set(LIBWALLY_LIBRARY wally)
-set(CFD_LIBRARY cfd)
-set(CFDCORE_LIBRARY cfdcore)
 
 if(MSVC)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Od /Zi")
@@ -106,6 +103,44 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# search cfd with PkgConfig.
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+pkg_check_modules(LIBCFD cfd)
+if(NOT CFD_FOUND)
+set(CFD_INSTALLED   FALSE)
+else()  # PkgConfig
+set(CFD_INSTALLED   ${CFD_FOUND})
+endif()
+else()
+set(CFD_INSTALLED   OFF)
+endif()
+
+if(WIN32 OR (NOT ${CFD_INSTALLED}))
+set(USE_INSTALLED_LIBRARY  FALSE)
+set(LIBWALLY_LIBRARY wally)
+set(CFD_LIBRARY cfd)
+set(CFDCORE_LIBRARY cfdcore)
+set(INSTALLED_LIBRARY_DIR "")
+set(INSTALLED_INCLUDE_DIR "./")
+else()
+set(USE_INSTALLED_LIBRARY  TRUE)
+pkg_check_modules(WALLY     REQUIRED wally)
+pkg_check_modules(CFDCORE   REQUIRED cfd-core)
+pkg_check_modules(LIBUNIVALUE  REQUIRED libunivalue)
+set(CFD_LIBRARY ${CFD_LIBRARIES})
+set(CFDCORE_LIBRARY ${CFDCORE_LIBRARIES})
+set(LIBWALLY_LIBRARY ${WALLY_LIBRARIES})
+set(UNIVALUE_LIBRARY ${LIBUNIVALUE_LIBRARIES})
+
+set(INSTALLED_LIBRARY_DIR ${CFD_LIBRARY_DIRS})
+set(INSTALLED_INCLUDE_DIR ${CFD_INCLUDE_DIRS})
+message(STATUS "[INSTALLED_LIBRARY_DIR]=${INSTALLED_LIBRARY_DIR}")
+message(STATUS "[INSTALLED_INCLUDE_DIR]=${INSTALLED_INCLUDE_DIR}")
+endif() # WIN32 OR (NOT ${CFDJS_API_FOUND})
+
+
 if(ENABLE_SHARED)
 add_library(${PROJECT_NAME} SHARED)
 else()
@@ -138,11 +173,13 @@ target_include_directories(${PROJECT_NAME}
   PRIVATE
     .
     include
+    ${INSTALLED_INCLUDE_DIR}
 )
 
 target_link_directories(${PROJECT_NAME}
   PRIVATE
     ./
+    ${INSTALLED_LIBRARY_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_policy(SET CMP0076 NEW)
 ####################
 # options
 ####################
+option(ENABLE_SHARED "enable shared library (ON or OFF. default:ON)" ON)
 option(ENABLE_DEBUG "enable debugging (ON or OFF. default:OFF)" OFF)
 
 if(NOT WIN32)
@@ -71,10 +72,44 @@ set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O0 -ggdb")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -ggdb")
 endif()
 
-set(LIBWALLY_LIBRARY wally)
-set(CFDCORE_LIBRARY cfdcore)
-set(CFD_LIBRARY cfd)
 set(CFD_DLC_LIBRARY cfddlc)
+
+# search cfd with PkgConfig.
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+pkg_check_modules(CFD cfd)
+if(NOT CFD_FOUND)
+set(CFD_INSTALLED   FALSE)
+else()  # PkgConfig
+set(CFD_INSTALLED   ${CFD_FOUND})
+endif()
+else()
+set(CFD_INSTALLED   FALSE)
+endif()
+
+if(WIN32 OR (NOT ${CFD_INSTALLED}))
+set(USE_INSTALLED_LIBRARY  FALSE)
+set(LIBWALLY_LIBRARY wally)
+set(CFD_LIBRARY cfd)
+set(CFDCORE_LIBRARY cfdcore)
+set(UNIVALUE_LIBRARY univalue)
+set(INSTALLED_LIBRARY_DIR "")
+set(INSTALLED_INCLUDE_DIR "./")
+else()
+set(USE_INSTALLED_LIBRARY  TRUE)
+pkg_check_modules(WALLY     REQUIRED wally)
+pkg_check_modules(CFDCORE   REQUIRED cfd-core)
+pkg_check_modules(LIBUNIVALUE  REQUIRED libunivalue)
+set(CFD_LIBRARY ${CFD_LIBRARIES})
+set(CFDCORE_LIBRARY ${CFDCORE_LIBRARIES})
+set(LIBWALLY_LIBRARY ${WALLY_LIBRARIES})
+set(UNIVALUE_LIBRARY ${LIBUNIVALUE_LIBRARIES})
+
+set(INSTALLED_LIBRARY_DIR ${CFD_LIBRARY_DIRS})
+set(INSTALLED_INCLUDE_DIR ${CFD_INCLUDE_DIRS})
+message(STATUS "[UNIVALUE_LIBRARY]=${UNIVALUE_LIBRARY}")
+endif() # WIN32 OR (NOT ${CFDJS_API_FOUND})
+
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -124,11 +159,13 @@ target_include_directories(${PROJECT_NAME}
     .
     ../src
     ${CFD_DLC_SRC_ROOT_DIR}/external/cfd-core/src/include
+    ${INSTALLED_INCLUDE_DIR}
 )
 
 target_link_directories(${PROJECT_NAME}
   PRIVATE
     ./
+    ${INSTALLED_LIBRARY_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -143,7 +180,7 @@ target_link_libraries(${PROJECT_NAME}
     ${CFDCORE_LIBRARY}
     ${CFD_LIBRARY}
     ${CFD_DLC_LIBRARY}
-    univalue
+    ${UNIVALUE_LIBRARY}
     gtest_main
     gmock
 )


### PR DESCRIPTION
support installed cfd build.

### quick build (use installed cfd)

use pkg-config.

- macos: `brew install pkg-config`

1. install cfd. (on initial or update only.)
```
git clone git@github.com:cryptogarageinc/cfd.git v0.0.10
cmake -S . -B build
cmake -DENABLE_SHARED=on -DENABLE_JS_WRAPPER=off -DENABLE_TESTS=off -DTARGET_RPATH=/usr/local/lib -DCMAKE_BUILD_TYPE=Release --build build
cmake --build build --parallel 4 --config Release
cd build && sudo make install -j 4
(or cmake --install build)
attention: support is shared library only.
```

update installed library, need cleanup installed file. script:
  `https://github.com/cryptogarageinc/cfd/blob/master/tools/cleanup_install_files.sh`

2. build cfd-dlc (on clean state)
```
./scripts/build.sh