### PR TITLE
Fix/support dllexport

### DIFF
--- a/include/dlc/Makefile.srclist
+++ b/include/dlc/Makefile.srclist
@@ -1,6 +1,7 @@
 # ./include/dlc/Makefile.inc
 
 CFD_DLC_PKGINCLUDE_FILES = \
+  dlc_common.h \
   dlc_exception.h \
   dlc_transactions.h \
   dlc_util.h

--- a/include/dlc/dlc_common.h
+++ b/include/dlc/dlc_common.h
@@ -1,0 +1,22 @@
+// Copyright 2019 CryptoGarage
+
+#ifndef DLC_DLC_COMMON_H_
+#define DLC_DLC_COMMON_H_
+
+#ifndef CFD_DLC_EXPORT
+#if defined(_WIN32)
+#ifdef CFD_DLC_BUILD
+#define CFD_DLC_EXPORT __declspec(dllexport)
+#elif defined(CFDDLC_SHARED)
+#define CFD_DLC_EXPORT __declspec(dllimport)
+#else
+#define CFD_DLC_EXPORT
+#endif
+#elif defined(__GNUC__) && defined(CFD_DLC_BUILD)
+#define CFD_DLC_EXPORT __attribute__((visibility("default")))
+#else
+#define CFD_DLC_EXPORT
+#endif
+#endif
+
+#endif  // DLC_DLC_COMMON_H_

--- a/include/dlc/dlc_transactions.h
+++ b/include/dlc/dlc_transactions.h
@@ -9,6 +9,7 @@
 #include "cfd/cfd_transaction.h"
 #include "cfdcore/cfdcore_address.h"
 #include "cfdcore/cfdcore_hdwallet.h"
+#include "dlc/dlc_common.h"
 
 namespace cfd {
 namespace dlc {
@@ -52,7 +53,7 @@ struct DlcOutcome {
  * @brief Class providing utility functions to create DLC transactions.
  *
  */
-class DlcManager {
+class CFD_DLC_EXPORT DlcManager {
  public:
   /**
    * @brief Create a Cet object

--- a/include/dlc/dlc_util.h
+++ b/include/dlc/dlc_util.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "cfdcore/cfdcore_key.h"
+#include "dlc/dlc_common.h"
 #include "secp256k1.h"  // NOLINT
 
 namespace cfd {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,10 +127,20 @@ target_compile_options(${PROJECT_NAME}
     >
     $<$<BOOL:$<CXX_COMPILER_ID:GNU>>:${STACK_PROTECTOR_OPT}>
 )
+
+if(ENABLE_SHARED)
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    CFD_DLC_BUILD=1
+    CFD_SHARED=1
+    CFD_CORE_SHARED=1
+)
+else()
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE
     CFD_DLC_BUILD=1
 )
+endif()
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC


### PR DESCRIPTION
dllexport is not set in cfd-dlc. As a result, in the Windows environment, it is not possible to link from the outside at the time of shared build.
Also, cdf-dlc itself lacked the definition to refer to the cfd-core and cfd shared libraries.