### PR TITLE
fix: set CFD_DLC_EXPORT to DlcUtil

### DIFF
--- a/include/dlc/dlc_util.h
+++ b/include/dlc/dlc_util.h
@@ -18,7 +18,7 @@ using cfd::core::ByteData256;
 using cfd::core::Privkey;
 using cfd::core::Pubkey;
 
-class DlcUtil {
+class CFD_DLC_EXPORT DlcUtil {
  public:
   static Pubkey GetCommittedKey(const Pubkey& oracle_pub_key,
                                 const std::vector<Pubkey>& oracle_r_points,


### PR DESCRIPTION
I'm sorry. The dllexport assignment was insufficient in the previous correspondence. 🙏 
(I noticed when I was checking cfd-dlc-js about cfd conflicts.)