### PR TITLE
Enable fewer messages than nonces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ external/libwally-core
 # generated doc
 doc/html*
 doc/latex
+
+.vscode

--- a/src/cfddlc_transactions.cpp
+++ b/src/cfddlc_transactions.cpp
@@ -194,8 +194,12 @@ AdaptorPair DlcManager::CreateCetAdaptorSignature(
     const std::vector<SchnorrPubkey>& oracle_r_values,
     const Privkey& funding_sk, const Script& funding_script_pubkey,
     const Amount& total_collateral, const std::vector<ByteData256>& msgs) {
+  std::vector<SchnorrPubkey> r_values;
+  for (size_t i = 0; i < msgs.size(); i++) {
+    r_values.push_back(oracle_r_values[i]);
+  }
   auto adaptor_point =
-      ComputeAdaptorPoint(msgs, oracle_r_values, oracle_pubkey);
+      ComputeAdaptorPoint(msgs, r_values, oracle_pubkey);
 
   auto sig_hash = cet.GetTransaction().GetSignatureHash(
       0, funding_script_pubkey.GetData(), SigHashType(), total_collateral,
@@ -206,7 +210,7 @@ AdaptorPair DlcManager::CreateCetAdaptorSignature(
 std::vector<AdaptorPair> DlcManager::CreateCetAdaptorSignatures(
     const std::vector<TransactionController>& cets,
     const SchnorrPubkey& oracle_pubkey,
-    const std::vector<SchnorrPubkey>& oracle_r_value, const Privkey& funding_sk,
+    const std::vector<SchnorrPubkey>& oracle_r_values, const Privkey& funding_sk,
     const Script& funding_script_pubkey, const Amount& total_collateral,
     const std::vector<std::vector<ByteData256>>& msgs) {
   size_t nb = cets.size();
@@ -218,7 +222,7 @@ std::vector<AdaptorPair> DlcManager::CreateCetAdaptorSignatures(
   std::vector<AdaptorPair> sigs;
   for (size_t i = 0; i < nb; i++) {
     sigs.push_back(CreateCetAdaptorSignature(
-        cets[i], oracle_pubkey, oracle_r_value, funding_sk,
+        cets[i], oracle_pubkey, oracle_r_values, funding_sk,
         funding_script_pubkey, total_collateral, msgs[i]));
   }
 
@@ -231,8 +235,12 @@ bool DlcManager::VerifyCetAdaptorSignature(
     const std::vector<SchnorrPubkey>& oracle_r_values,
     const Script& funding_script_pubkey, const Amount& total_collateral,
     const std::vector<ByteData256>& msgs) {
+  std::vector<SchnorrPubkey> r_values;
+  for (size_t i = 0; i < msgs.size(); i++) {
+    r_values.push_back(oracle_r_values[i]);
+  }
   auto adaptor_point =
-      ComputeAdaptorPoint(msgs, oracle_r_values, oracle_pubkey);
+      ComputeAdaptorPoint(msgs, r_values, oracle_pubkey);
   auto sig_hash = cet.GetTransaction().GetSignatureHash(
       0, funding_script_pubkey.GetData(), SigHashType(), total_collateral,
       WitnessVersion::kVersion0);

--- a/src/cfddlc_transactions.cpp
+++ b/src/cfddlc_transactions.cpp
@@ -304,7 +304,7 @@ void DlcManager::SignCet(TransactionController* cet,
     throw new CfdException(CfdError::kCfdIllegalArgumentError,
                            "Public key not part of the multi sig script.");
   }
-}
+}  // namespace dlc
 
 ByteData DlcManager::GetRawFundingTransactionInputSignature(
     const TransactionController& funding_transaction, const Privkey& privkey,

--- a/test/test_cfddlc_transactions.cpp
+++ b/test/test_cfddlc_transactions.cpp
@@ -594,7 +594,7 @@ TEST(DlcManager, AdaptorSigMultipleNoncesWithFewerMessagesThanNonces) {
 
   EXPECT_TRUE(DlcManager::VerifyCetAdaptorSignature(
       adaptor_pairs[1], cets[1], LOCAL_FUND_PUBKEY, ORACLE_PUBKEY,
-      ORACLE_R_POINTS, lock_script, fund_amount, LOSE_MESSAGES_HASH_FEWER_MESSAGES));
+      {ORACLE_R_POINTS[0]}, lock_script, fund_amount, LOSE_MESSAGES_HASH_FEWER_MESSAGES));
 
   auto adaptor_secret = ORACLE_SIGNATURES[0].GetPrivkey();
   auto adapted_sig =

--- a/test/test_cfddlc_transactions.cpp
+++ b/test/test_cfddlc_transactions.cpp
@@ -43,6 +43,10 @@ const std::vector<ByteData256> WIN_MESSAGES_HASH = {
     HashUtil::Sha256(WIN_MESSAGES[0]), HashUtil::Sha256(WIN_MESSAGES[1])};
 const std::vector<ByteData256> LOSE_MESSAGES_HASH = {
     HashUtil::Sha256(LOSE_MESSAGES[0]), HashUtil::Sha256(LOSE_MESSAGES[1])};
+const std::vector<ByteData256> WIN_MESSAGES_HASH_FEWER_MESSAGES = {
+    HashUtil::Sha256(WIN_MESSAGES[0])};
+const std::vector<ByteData256> LOSE_MESSAGES_HASH_FEWER_MESSAGES = {
+    HashUtil::Sha256(LOSE_MESSAGES[0])};
 const std::vector<std::vector<ByteData256>> MESSAGES_HASH = {
     WIN_MESSAGES_HASH, LOSE_MESSAGES_HASH};
 const Privkey ORACLE_PRIVKEY(
@@ -560,6 +564,39 @@ TEST(DlcManager, AdaptorSigMultipleNonces) {
   auto adaptor_secret = ORACLE_SIGNATURES[0].GetPrivkey();
   adaptor_secret = adaptor_secret.CreateTweakAdd(
       ByteData256(ORACLE_SIGNATURES[1].GetPrivkey().GetData()));
+  auto adapted_sig =
+      AdaptorUtil::Adapt(adaptor_pairs[0].signature, adaptor_secret);
+
+  auto is_valid = cet0.VerifyInputSignature(
+      adapted_sig, LOCAL_FUND_PUBKEY, fund_txid, 0, lock_script, SigHashType(),
+      fund_amount, WitnessVersion::kVersion0);
+  EXPECT_TRUE(is_valid);
+}
+
+TEST(DlcManager, AdaptorSigMultipleNoncesWithFewerMessagesThanNonces) {
+  std::vector<DlcOutcome> outcomes = {{WIN_AMOUNT, LOSE_AMOUNT},
+                                      {LOSE_AMOUNT, WIN_AMOUNT}};
+  auto dlc_transactions = DlcManager::CreateDlcTransactions(
+      outcomes, LOCAL_PARAMS, REMOTE_PARAMS, REFUND_LOCKTIME, 1, PREMIUM_DEST,
+      OPTION_PREMIUM);
+  auto fund_transaction = dlc_transactions.fund_transaction;
+  auto cets = dlc_transactions.cets;
+  auto cet0 = cets[0];
+  auto lock_script = DlcManager::CreateFundTxLockingScript(LOCAL_FUND_PUBKEY,
+                                                           REMOTE_FUND_PUBKEY);
+
+  auto fund_amount = fund_transaction.GetTransaction().GetTxOut(0).GetValue();
+  auto fund_txid = fund_transaction.GetTransaction().GetTxid();
+
+  auto adaptor_pairs = DlcManager::CreateCetAdaptorSignatures(
+      cets, ORACLE_PUBKEY, ORACLE_R_POINTS, LOCAL_FUND_PRIVKEY, lock_script,
+      fund_amount, {WIN_MESSAGES_HASH_FEWER_MESSAGES, LOSE_MESSAGES_HASH_FEWER_MESSAGES});
+
+  EXPECT_TRUE(DlcManager::VerifyCetAdaptorSignature(
+      adaptor_pairs[1], cets[1], LOCAL_FUND_PUBKEY, ORACLE_PUBKEY,
+      ORACLE_R_POINTS, lock_script, fund_amount, LOSE_MESSAGES_HASH_FEWER_MESSAGES));
+
+  auto adaptor_secret = ORACLE_SIGNATURES[0].GetPrivkey();
   auto adapted_sig =
       AdaptorUtil::Adapt(adaptor_pairs[0].signature, adaptor_secret);
 


### PR DESCRIPTION
Since DLC CET compression involves outputs requiring fewer nonces, this PR enables fewer messages than nonces to be passed into `CreateCetAdaptorSignature` and `VerifyCetAdaptorSignature`, which calculates the adaptor point based nonces up to the length of msgs array. 

[Numeric Outcome Details](https://github.com/discreetlogcontracts/dlcspecs/blob/d6c6816b50ee33df7b8e8cca4d6314fe16fbee5e/NumericOutcome.md)