### PR TITLE
Ensure fewer messages can be provided than r values

### DIFF
--- a/src/cfddlc_transactions.cpp
+++ b/src/cfddlc_transactions.cpp
@@ -206,7 +206,7 @@ AdaptorPair DlcManager::CreateCetAdaptorSignature(
 std::vector<AdaptorPair> DlcManager::CreateCetAdaptorSignatures(
     const std::vector<TransactionController>& cets,
     const SchnorrPubkey& oracle_pubkey,
-    const std::vector<SchnorrPubkey>& oracle_r_value, const Privkey& funding_sk,
+    const std::vector<SchnorrPubkey>& oracle_r_values, const Privkey& funding_sk,
     const Script& funding_script_pubkey, const Amount& total_collateral,
     const std::vector<std::vector<ByteData256>>& msgs) {
   size_t nb = cets.size();
@@ -217,8 +217,17 @@ std::vector<AdaptorPair> DlcManager::CreateCetAdaptorSignatures(
 
   std::vector<AdaptorPair> sigs;
   for (size_t i = 0; i < nb; i++) {
+    if (oracle_r_values.size() < msgs[i].size()) {
+      throw CfdException(
+        CfdError::kCfdIllegalArgumentError,
+        "Number of r values must be greater or equal to number of messages.");
+    }
+    std::vector<SchnorrPubkey> r_values;
+    for (size_t j = 0; j < msgs[i].size(); j++) {
+      r_values.push_back(oracle_r_values[j]);
+    }
     sigs.push_back(CreateCetAdaptorSignature(
-        cets[i], oracle_pubkey, oracle_r_value, funding_sk,
+        cets[i], oracle_pubkey, r_values, funding_sk,
         funding_script_pubkey, total_collateral, msgs[i]));
   }
 
@@ -257,9 +266,18 @@ bool DlcManager::VerifyCetAdaptorSignatures(
   bool all_valid = true;
 
   for (size_t i = 0; i < nb && all_valid; i++) {
+    if (oracle_r_values.size() < msgs[i].size()) {
+      throw CfdException(
+        CfdError::kCfdIllegalArgumentError,
+        "Number of r values must be greater or equal to number of messages.");
+    }
+    std::vector<SchnorrPubkey> r_values;
+    for (size_t j = 0; j < msgs[i].size(); j++) {
+      r_values.push_back(oracle_r_values[j]);
+    }
     all_valid &= VerifyCetAdaptorSignature(
         signature_and_proofs[i], cets[i], pubkey, oracle_pubkey,
-        oracle_r_values, funding_script_pubkey, total_collateral, msgs[i]);
+        r_values, funding_script_pubkey, total_collateral, msgs[i]);
   }
 
   return all_valid;


### PR DESCRIPTION
This PR adds the ability to pass in fewer messages than r values to `CreateCetAdaptorSignatures` and `VerifyCetAdaptorSignatures` to allow for fewer r values to be used than specified